### PR TITLE
Add a property of function 'lt' and fix no existing abbr errors

### DIFF
--- a/src/pug/lt/_lt.pug
+++ b/src/pug/lt/_lt.pug
@@ -1,8 +1,7 @@
-mixin lt(time, title, url, presenter, icon, span, rest)
+mixin lt(time, abbr, title, url, presenter, icon, span, rest)
   tr
     dt.time
-      //- time= time + ' ' + part.abbr
-      time= time
+      time= time + ' ' + abbr
     dd.description(class='span_'+span class=rest ? 'dotted' : '')
       a(href=url)
         h3.title= title

--- a/src/pug/lt/index.pug
+++ b/src/pug/lt/index.pug
@@ -15,5 +15,5 @@ html(lang="ja")
         h2.part= part.name
         dl.lt-table
           each lt in part.lts
-            +lt(lt.time, lt.title, lt.url, lt.presenter, lt.icon, lt.span, lt.rest)
+            +lt(lt.time, part.abbr, lt.title, lt.url, lt.presenter, lt.icon, lt.span, lt.rest)
     +footer()


### PR DESCRIPTION
mixin `lt` に `abbr` を渡していなかった… 😇 