### PR TITLE
Revert "Skip CI when deploying from develop to master"

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -57,8 +57,7 @@ const BROWSER_SYNC_OPTIONS = {
 };
 
 const GH_PAGES_OPTIONS = {
-    branch: "master",
-    commit: "[ci skip] Update Pages"
+    branch: "master"
 };
 
 gulp.task("yaml", () => {


### PR DESCRIPTION
This reverts commit 3dc4c90890e2d1f0f1a91910d3ecb53707c3d607.